### PR TITLE
Add T6 gsc utils file io functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,24 @@ Detours and reimplements the entire GSC VM + compiler.
 
 Adds custom GSC functions.
 
-## FileIO
-This plugin provides FileIO interface to GSC for reading and writing files, this is exact to [CoD4x's](https://github.com/callofduty4x/CoD4x_Server/blob/master/scriptdocumentation/script_functions_reference.md#file-operations) interface.
+# FileIO
+This plugin provides FileIO interface to GSC for reading and writing files.
+
+## T6 gsc utils io functions
+
+* ```fileExists(path)```: Returns true if the file exists.
+
+* ```writeFile(path, data[, append])```: Creates a file if it doesn't exist and writes/appends text to it.
+
+* ```readFile(path)```: Reads a file.
+
+* ```createDirectory(path)```: Creates a directory and returns false if failed creating directories.
+
+* ```directoryExists(path)```: Returns true if the directory exists.
+
+## CoD4x io function
+
+This is exact to [CoD4x's](https://github.com/callofduty4x/CoD4x_Server/blob/master/scriptdocumentation/script_functions_reference.md#file-operations) interface.
 
 However, all reads and writes will take place strictly and only in the `scriptdata` folder, no up directory traversal allowed.
 

--- a/src/component/fileio.cpp
+++ b/src/component/fileio.cpp
@@ -197,9 +197,6 @@ namespace fileio
 						auto fd = 0;
 						auto file_length = game::FS_FOpenFileRead(fpath.c_str(), &fd);
 
-						printf("FD %d", fd);
-						printf("FILE LENGHT %d", file_length);
-
 						if (!fd || file_length < 0)
 						{
 							game::Com_PrintWarning(game::CON_CHANNEL_SCRIPT, "Failed to open file for reading: %s\n", fpath.c_str());

--- a/src/component/fileio.cpp
+++ b/src/component/fileio.cpp
@@ -32,6 +32,7 @@ namespace fileio
 
 		std::array<scr_fh_t, max_fhs> scr_fhs = {};
 
+
 		bool validate_scr_path(const std::string& fpath)
 		{
 			if (fpath.empty())
@@ -195,6 +196,9 @@ namespace fileio
 					{
 						auto fd = 0;
 						auto file_length = game::FS_FOpenFileRead(fpath.c_str(), &fd);
+
+						printf("FD %d", fd);
+						printf("FILE LENGHT %d", file_length);
 
 						if (!fd || file_length < 0)
 						{
@@ -417,6 +421,63 @@ namespace fileio
 					}
 
 					game::FS_FreeFileList(files);
+				});
+
+			gsc::function::add("writefile", []()
+				{
+					const auto path = game::Scr_GetString(0, game::SCRIPTINSTANCE_SERVER);
+					const auto data = game::Scr_GetString(1, game::SCRIPTINSTANCE_SERVER);
+
+					auto append = false;
+					if (game::Scr_GetNumParam(game::SCRIPTINSTANCE_SERVER) > 2)
+					{
+						append = game::Scr_GetInt(game::SCRIPTINSTANCE_SERVER, 2);
+					}
+
+					game::Scr_AddInt(game::SCRIPTINSTANCE_SERVER, utils::io::write_file(path, data, append));
+				});
+
+			gsc::function::add("readfile", []()
+				{
+					const auto path = game::Scr_GetString(0, game::SCRIPTINSTANCE_SERVER);
+					game::Scr_AddString(game::SCRIPTINSTANCE_SERVER, utils::io::read_file(path).c_str());
+				});
+
+			gsc::function::add("fileexists", []()
+				{
+					const auto path = game::Scr_GetString(0, game::SCRIPTINSTANCE_SERVER);
+					
+					if (!utils::io::file_exists(path))
+					{
+						game::Scr_AddInt(game::SCRIPTINSTANCE_SERVER, 0);
+						return;
+					}
+
+					game::Scr_AddInt(game::SCRIPTINSTANCE_SERVER, 1);
+				});
+			
+			gsc::function::add("createdirectory", []()
+				{
+					const auto path = game::Scr_GetString(0, game::SCRIPTINSTANCE_SERVER);
+					if (!utils::io::create_directory(path))
+					{
+						game::Scr_AddInt(game::SCRIPTINSTANCE_SERVER, 0);
+						return;
+					}
+
+					game::Scr_AddInt(game::SCRIPTINSTANCE_SERVER, 1);
+				});
+
+			gsc::function::add("directoryexists", []()
+				{
+					const auto path = game::Scr_GetString(0, game::SCRIPTINSTANCE_SERVER);
+					if(!utils::io::directory_exists(path))
+					{
+						game::Scr_AddInt(game::SCRIPTINSTANCE_SERVER, 0);
+						return;
+					}
+
+					game::Scr_AddInt(game::SCRIPTINSTANCE_SERVER, 1);
 				});
 		}
 	}


### PR DESCRIPTION
Since CoD4x fileio functions are limited to inside scriptdata folder here is io functions from t6 gsc utils.

* directoryexists
* createdirectory
* fileexists
* readfile
* writefile
